### PR TITLE
Editor UI & UX improvements: tooltips, shortcuts, chunking

### DIFF
--- a/Front-end/package-lock.json
+++ b/Front-end/package-lock.json
@@ -13,6 +13,7 @@
 				"@monaco-editor/react": "^4.7.0",
 				"@tailwindcss/postcss": "^4.0.0",
 				"@tailwindcss/vite": "^4.0.0",
+				"@tippyjs/react": "^4.2.5",
 				"axios": "^1.7.9",
 				"bcrypt": "^5.1.1",
 				"chart.js": "^4.4.7",
@@ -43,6 +44,7 @@
 				"tailwind-merge": "^3.2.0",
 				"tailwindcss": "^4.0.0",
 				"three": "^0.172.0",
+				"tippy.js": "^6.3.7",
 				"tsparticles": "^3.8.0",
 				"uuid": "^11.1.0"
 			},
@@ -1607,6 +1609,15 @@
 				"node": ">= 18"
 			}
 		},
+		"node_modules/@popperjs/core": {
+			"version": "2.11.8",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/popperjs"
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.32.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.0.tgz",
@@ -2116,6 +2127,18 @@
 			},
 			"peerDependencies": {
 				"vite": "^5.2.0 || ^6"
+			}
+		},
+		"node_modules/@tippyjs/react": {
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz",
+			"integrity": "sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==",
+			"dependencies": {
+				"tippy.js": "^6.3.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8",
+				"react-dom": ">=16.8"
 			}
 		},
 		"node_modules/@ts-morph/common": {
@@ -9518,6 +9541,14 @@
 			"resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
 			"integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==",
 			"license": "MIT"
+		},
+		"node_modules/tippy.js": {
+			"version": "6.3.7",
+			"resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+			"integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+			"dependencies": {
+				"@popperjs/core": "^2.9.0"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",

--- a/Front-end/package.json
+++ b/Front-end/package.json
@@ -45,6 +45,8 @@
 		"slick-carousel": "^1.8.1",
 		"socket.io": "^4.8.1",
 		"socket.io-client": "^4.8.1",
+		"@tippyjs/react": "^4.2.5",
+		"tippy.js": "^6.3.7",
 		"tailwind-merge": "^3.2.0",
 		"tailwindcss": "^4.0.0",
 		"three": "^0.172.0",

--- a/Front-end/src/Components/Terminal/editor.css
+++ b/Front-end/src/Components/Terminal/editor.css
@@ -1,0 +1,23 @@
+.editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: linear-gradient(90deg, #0f1724, #121827);
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.editor-header .left {
+  display:flex;
+  gap:12px;
+  align-items:center;
+}
+.editor-header .logo {
+  width:28px; height:28px; border-radius:6px; object-fit:cover;
+}
+.editor-header h1 { font-size:14px; margin:0; color:#e6edf3; font-weight:600 }
+.editor-header .badge { font-size:12px; color:#9aa4b2 }
+.editor-actions { display:flex; gap:8px; align-items:center }
+.editor-btn { background:transparent; border:1px solid rgba(255,255,255,0.04); padding:6px 8px; border-radius:6px; color:#cbd5e1; cursor:pointer }
+.editor-btn:hover { background:rgba(255,255,255,0.02) }
+.save-indicator { font-size:12px; color:#8bdf7f; margin-left:8px }
+.play-btn { background:linear-gradient(90deg,#0ea5e9,#6366f1); border:none; color:white }

--- a/Front-end/vite.config.js
+++ b/Front-end/vite.config.js
@@ -20,6 +20,19 @@ export default defineConfig({
       include: [/node_modules/],
       extensions: ['.js', '.jsx']
     }
+    ,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('@monaco-editor') || id.includes('monaco-editor')) return 'monaco';
+            if (id.includes('react') || id.includes('react-dom')) return 'react-vendor';
+            if (id.includes('tippy.js') || id.includes('@tippyjs')) return 'tippy';
+            return 'vendor';
+          }
+        }
+      }
+    }
   },
   optimizeDeps: {
     include: ['three', 'postprocessing']


### PR DESCRIPTION
This PR adds tooltips (Tippy), keyboard shortcuts (Ctrl/Cmd+S to save, Ctrl/Cmd+Enter to run), lazy-loaded Monaco editor, and Vite manualChunks config to improve bundle sizes. Also modernizes the editor toolbar styling and fixes server/client real-time event handling.